### PR TITLE
Fix excessive number of images per product

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -23,7 +23,7 @@ parameters:
     range_prices: 100
     range_weights: 100
     product_attributes: 5
-    images: 100
+    images: 3
     order_messages: 100
     deliveries: 100
     connections: 1000


### PR DESCRIPTION

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Create 100 images per product is excessive.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | no
| Possible impacts? | Faster data generation
