### PR TITLE
Fix error when adress country is ES_es and dni is mandatory

### DIFF
--- a/src/Model/Address.yml
+++ b/src/Model/Address.yml
@@ -44,7 +44,7 @@ fields:
           args:
             - 6
         dni:
-          value: ''
+          value: '77446565E'
         active:
           type: boolean
           args:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Because of required field dni on ES country address an error happened if the value is empty. A fixed value is set to prevent this error. The value can be the same for each addresses.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #8 
| How to test?      | Generate example data > Set one address with id_country "ES" and set dni to blank > ![image](https://user-images.githubusercontent.com/6594752/196458688-208782cb-c749-4a69-bfb9-4eac15f1071e.png) > You should not have the error "Property Address->dni is empty"
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
