### PR TITLE
fix error when 2 product suppliers have the same ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,29 @@ The model file is in yml format, and contains three main section:
         sports
         technics 
         transport
-        ```                                        
+        ```
+
+   7. <i><b>unique (optional)</b></i>
+
+        This option can be used to define unique combination of fields to generate entities.
+        Example :
+      ```yaml
+        fields:
+            class: 'ProductSupplier'
+            unique: 'id_product,id_product_attribute,id_supplier'
+            columns:
+                id_product:
+                  relation: Product
+                  generate_all: true
+                id_product_attribute:
+                  relation: ProductAttribute
+                id_supplier:
+                  relation: Supplier
+                product_supplier_reference:
+                  value: ''
+                product_supplier_price_te:
+                  value: 0
+        ```
 
 2. <b>The fields_lang section (optional)</b>
 

--- a/src/Generator/EntityGenerator.php
+++ b/src/Generator/EntityGenerator.php
@@ -398,7 +398,13 @@ class EntityGenerator
     private function generateMainEntityData(\SimpleXMLElement $element, &$relationValues = null)
     {
         $this->fieldValues = [];
-        $child = new \SimpleXMLElement('<' .$this->entityElementName.'>'.'</' .$this->entityElementName.'>');
+        $child = new \SimpleXMLElement(
+            sprintf(
+                '<%s></%s>',
+                $this->entityElementName,
+                $this->entityElementName
+            )
+        );
         $this->relationList[$this->entityElementName] = [];
         $idValue = null;
         $relationLists = $relationConditions = $valueAttributes = $fakerAttributes = [];

--- a/src/Generator/EntityGenerator.php
+++ b/src/Generator/EntityGenerator.php
@@ -83,6 +83,9 @@ class EntityGenerator
     /** @var array Array of already generated img to be reused to speed up the generation process */
     protected $generatedImgs = [];
 
+    /** @var array Array of already unique associated keys generated */
+    protected $existingChildKeys = [];
+
     /**
      * EntityGenerator constructor.
      *
@@ -301,6 +304,7 @@ class EntityGenerator
     {
         $this->relationValues = [];
         $entityData = $this->generateMainEntityData($child, $relationValues);
+        $this->sxml_append($child, $entityData);
         if (array_key_exists($this->id, (array)$entityData)) {
             $idValue = $entityData[$this->id];
         } else {
@@ -394,7 +398,7 @@ class EntityGenerator
     private function generateMainEntityData(\SimpleXMLElement $element, &$relationValues = null)
     {
         $this->fieldValues = [];
-        $child = $element->addChild($this->entityElementName);
+        $child = new \SimpleXMLElement('<' .$this->entityElementName.'>'.'</' .$this->entityElementName.'>');
         $this->relationList[$this->entityElementName] = [];
         $idValue = null;
         $relationLists = $relationConditions = $valueAttributes = $fakerAttributes = [];
@@ -490,7 +494,36 @@ class EntityGenerator
             }
         }
 
+        if (isset($this->entityModel['fields']['unique'])) {
+            $uniqueFields = explode(',', $this->entityModel['fields']['unique']);
+            $key = [];
+            foreach ($uniqueFields as $uniqueField) {
+                $key[] = (string) $child->attributes()[$uniqueField];
+            }
+            $key = implode('-', $key);
+
+            if (in_array($key, $this->existingChildKeys)) {
+                $child = $this->generateMainEntityData($element, $relationValues);
+            }
+
+            $this->existingChildKeys[] = $key;
+        }
+
         return $child;
+    }
+
+    /**
+     * Append SimpleXMLElement to another SimpleXMLElement
+     *
+     * @param \SimpleXMLElement $to
+     * @param \SimpleXMLElement $from
+     *
+     * @return void
+     */
+    function sxml_append(\SimpleXMLElement $to, \SimpleXMLElement $from): void {
+        $toDom = dom_import_simplexml($to);
+        $fromDom = dom_import_simplexml($from);
+        $toDom->appendChild($toDom->ownerDocument->importNode($fromDom, true));
     }
 
     /**
@@ -683,141 +716,6 @@ class EntityGenerator
     }
 
     /**
-     * Compute the relation by checking if the relationName is not part of already generated relation from the entity
-     *
-     * @param string $relationName
-     * @param string $entityName
-     *
-     * @return \SimpleXMLElement
-     */
-    private function getRelationFromDependencies($relationName, $entityName)
-    {
-        // first get all the relations inside the entity
-        $relationEntity = null;
-        $relations = $this->relationList[$entityName];
-        foreach ($relations as $relation) {
-            // and check if this relation has itself relations
-            if (array_key_exists($relation, $this->relationList)) {
-                $relatedRelations = $this->relationList[$relation];
-                // if the relation we are generating is also part of another relation
-                if ($relationFieldName = array_search($relationName, $relatedRelations)) {
-                    // we have generated the dependent entity earlier, we should use the values from this entity
-                    // instead of a random one
-                    if (array_key_exists($relation, $this->relationValues)) {
-                        // relations are indexed by id, so to get the proper relation, just use the relationValues which
-                        // contains the id of the already generated dependent entity
-                        $dependentRelation = $this->relations[$relation][$this->relationValues[$relation]];
-                        $newKey = (string)($dependentRelation[$relationFieldName]);
-                        if (!empty($newKey)) {
-                            // finally get the relation using the value stored in the dependency
-                            $relationEntity = $this->relations[$relationName][$newKey];
-                        }
-                        break;
-                    }
-                }
-            }
-        }
-
-        if (empty($relationEntity)) {
-            $relationEntity = $this->getRelationWithMatchingFieldsFromDependencies($relationName);
-        }
-
-        return $relationEntity;
-    }
-
-    /**
-     * Get a relation with fields which match the already generated fields in dependencies
-     *
-     * @param string $relationName
-     *
-     * @return \SimpleXMLElement
-     */
-    private function getRelationWithMatchingFieldsFromDependencies($relationName)
-    {
-        static $lastRelationList = null;
-        if ($lastRelationList === null) {
-            $lastRelationList = $this->relations[$relationName];
-        }
-        // get the relations inside the current relation
-        if (!array_key_exists($relationName, $this->relationList)) {
-            return null;
-        }
-        $relationFieldValue = [];
-        $relations = $this->relationList[$relationName];
-        // get the list of the generated relations
-        $generatedRelations = array_keys($this->relationValues);
-        foreach ($generatedRelations as $generatedRelation) {
-            if (array_key_exists($generatedRelation, $this->relationList)) {
-                // get the relations inside the generatedRelation
-                $relationsFromRelations = $this->relationList[$generatedRelation];
-                // get the common relations between the current relation and the others
-                $commonRelations = array_intersect($relations, $relationsFromRelations);
-
-                // get the content of the generated relation
-                $dependentRelation = $this->relations[$generatedRelation][$this->relationValues[$generatedRelation]];
-                // get the effective value we expect for cross dependent field
-                if (!empty($commonRelations)) {
-                    foreach ($commonRelations as $key => $value) {
-                        $dependentValue = (string)($dependentRelation[$key]);
-                        // skip null value
-                        if ($dependentValue != '') {
-                            $relationFieldValue[$key] = (string)($dependentRelation[$key]);
-                        }
-                    }
-                }
-            }
-        }
-
-        if (empty($relationFieldValue)) {
-            return null;
-        }
-
-        $potentialRelation = $this->getMatchingRelation(
-            $lastRelationList,
-            $relationFieldValue
-        );
-
-        // just in case, if we found no value with the reduced relation list, retry with the full list
-        if (empty($potentialRelation)) {
-            $lastRelationList = $this->relations[$relationName];
-            $potentialRelation = $this->getMatchingRelation(
-                $lastRelationList,
-                $relationFieldValue
-            );
-        }
-
-        return $potentialRelation;
-    }
-
-    /**
-     * Find inside the relations array the relation with the matching entries from relationFieldValue
-     *
-     * @param array $relations
-     * @param array $relationFieldValue
-     *
-     * @return null
-     */
-    private function getMatchingRelation(&$relations, $relationFieldValue)
-    {
-        // check the fields of the already generated relations match the current randomRelation
-        foreach($relations as $relationKey => $potentialRelation) {
-            foreach ($relationFieldValue as $key => $value) {
-                $potentialRelationValue = (string)($potentialRelation[$key]);
-                // not matching, try another relation
-                if ($potentialRelationValue != $value) {
-                    // optimization, we use a dynamic relation list from where we remove non matching elements
-                    unset($relations[$relationKey]);
-                    continue 2;
-                }
-            }
-
-            return $potentialRelation;
-        }
-
-        return null;
-    }
-
-    /**
      * Check the randomRelation match the given relationConditions
      *
      * @param array $relationConditions
@@ -847,17 +745,11 @@ class EntityGenerator
      *
      * @param string $relationName
      * @param array  $relationConditions
-     * @param string $entityName
      *
      * @return string
      */
-    private function getRandomRelationId($relationName, $relationConditions, $entityName)
+    private function getRandomRelationId($relationName, $relationConditions)
     {
-        // if the current relation is also inside an already generated relation, use it instead of a random value
-        if ($relation = $this->getRelationFromDependencies($relationName, $entityName)) {
-            return (string)($relation['id']);
-        }
-
         do {
             // a random relation value
             $randomRelation = $this->relations[$relationName][array_rand($this->relations[$relationName])];

--- a/src/Model/ProductSupplier.yml
+++ b/src/Model/ProductSupplier.yml
@@ -1,5 +1,6 @@
 fields:
     class: 'ProductSupplier'
+    unique: 'id_product,id_product_attribute,id_supplier'
     columns:
         id_product:
           relation: Product


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix error when 2 product suppliers have the same id with adding option to make a line unique with parameters. Also delete functions seems useless to make generate entities more efficient.
| Type?             | bug fix + improvement
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #21 
| How to test?      | See #21 
| Possible impacts? |
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
