### PR TITLE
Avoid infinite loop when we can't find a matching relation with conditions

### DIFF
--- a/src/Generator/EntityGenerator.php
+++ b/src/Generator/EntityGenerator.php
@@ -858,9 +858,19 @@ class EntityGenerator
             return (string)($relation['id']);
         }
 
+        $maxRetry = 1000;
+        $try = 1;
         do {
             // a random relation value
             $randomRelation = $this->relations[$relationName][array_rand($this->relations[$relationName])];
+            if ($try >= $maxRetry) {
+                throw new RuntimeException(
+                    'A '. $relationName . ' relation can\'t be found for entity ' . $entityName
+                    . ' with these conditions : ' . http_build_query($relationConditions,'',', ')
+                    . ' try to adapt config.yml or entity files in src/Model'
+                );
+            }
+            $try++;
         } while (!$this->isMatchingConditions($relationConditions, $randomRelation));
 
         return (string)($randomRelation['id']);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Avoid infinite loop when we can't find a matching relation with conditions by adding a stop conditions with 1000 retry. Add a message to explain what we can change to avoid this error. This PR does not solve completely the problem but introduce mitigation steps that should allow avoiding the problem in most cases.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #12 
| How to test?      | See #12 
| Possible impacts? | ~

On the example provided in #12 the guest entity is blocked because we try to generate guest information and we need a customer guest for that.
However in the config.yml file, we have set we need only 1 customer. In the definition of the customer entity, the customer can be a guest only with 10% chance. So if you're lucky, you have a customer and it works, if you're not lucky... it fails. This PR does not solve completely the problem but introduce mitigation steps that should allow avoiding the problem in most cases by performing retries.

![image](https://user-images.githubusercontent.com/6594752/198986151-32408b54-02b6-4041-add7-ae67b473d7d3.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
