### PR TITLE
Fixing dependancies sorting issue "You first need to define an entry before using a relation with"

### DIFF
--- a/src/Service/XMLGeneratorService.php
+++ b/src/Service/XMLGeneratorService.php
@@ -132,6 +132,7 @@ class XMLGeneratorService
             $modelType = str_replace('.yml', '', $file->getFilename());
             $yamlContent = file_get_contents($pathName);
             if (preg_match_all('/relation:\W*(.+)$/uim', $yamlContent, $matches)) {
+                $dependency = str_ireplace(["\r","\n",'\r','\n'], '', $dependency);
                 foreach ($matches[1] as $dependency) {
                     if ($dependency != $modelType) {
                         $dependencies[$dependency][] = $modelType;


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Because of cariage return symbol dependancies sorting was working incorectly this is why you can get and error "You first need to define an entry before using a relation with %"
| Type?             | bug fix
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #4 https://github.com/PrestaShop/prestashop-shop-creator/issues/4
| Sponsor company   | Elpresta
